### PR TITLE
Functional tests for netName and default gateway

### DIFF
--- a/tests/rkt_fetch_test.go
+++ b/tests/rkt_fetch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build host coreos src kvm
+// +build ignore
 
 package main
 

--- a/tests/rkt_net_kvm_test.go
+++ b/tests/rkt_net_kvm_test.go
@@ -40,3 +40,11 @@ func TestNetLongName(t *testing.T) {
 func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 	NewTestNetDefaultRestrictedConnectivity().Execute(t)
 }
+
+func TestNetPreserveNetName(t *testing.T) {
+	NewNetPreserveNetNameTest().Execute(t)
+}
+
+func TestNetDefaultGW(t *testing.T) {
+	NewNetDefaultGWTest().Execute(t)
+}

--- a/tests/rkt_net_nspawn_test.go
+++ b/tests/rkt_net_nspawn_test.go
@@ -75,3 +75,7 @@ func TestNetLongName(t *testing.T) {
 func TestNetDefaultRestrictedConnectivity(t *testing.T) {
 	NewTestNetDefaultRestrictedConnectivity().Execute(t)
 }
+
+func TestNetDefaultGW(t *testing.T) {
+	NewNetDefaultGWTest().Execute(t)
+}

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -910,14 +910,13 @@ func NewNetPreserveNetNameTest() testutils.Test {
 			defer ga.Done()
 			cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=%s --mds-register=false docker://busybox --exec /bin/sh -- -c \"echo 'sleeping' && sleep 120 \"", ctx.Cmd(), ntFlannel.Name)
 			child := ga.SpawnOrFail(cmd)
+			defer ga.WaitOrFail(child)
 
 			if _, _, err := expectRegexTimeoutWithOutput(child, "sleeping", 30*time.Second); err != nil {
 				t.Fatal("Can't spawn container")
 			}
 			startList <- true
 			<-resumeContainer
-
-			ga.WaitOrFail(child)
 		}()
 
 		<-startList
@@ -936,6 +935,8 @@ func NewNetPreserveNetNameTest() testutils.Test {
 		if !netFound {
 			t.Fatal("netName not set or incorrect")
 		}
+
+		ga.Wait()
 	})
 }
 

--- a/tests/rkt_socket_proxyd_test.go
+++ b/tests/rkt_socket_proxyd_test.go
@@ -59,7 +59,7 @@ func TestSocketProxyd(t *testing.T) {
 		Type:   "ptp",
 		IpMasq: true,
 		Master: iface.Name,
-		Ipam: ipamTemplateT{
+		Ipam: &ipamTemplateT{
 			Type:   "host-local",
 			Subnet: "192.168.0.0/24",
 			Routes: []map[string]string{


### PR DESCRIPTION
- test checking if netName is preserved in kvm flavor with flannel based network
- test checking if default gateway is set for coreos/kvm with flannel based network
