### PR TITLE
rkt-monitor: misc fixes

### DIFF
--- a/tests/rkt-monitor/README.md
+++ b/tests/rkt-monitor/README.md
@@ -15,6 +15,9 @@ rkt-monitor mem-stresser.aci -v -d 30s
 
 Flags:
   -f, --to-file[=false]: Save benchmark results to files in a temp dir
+  -w, --output-dir="/tmp": Specify directory to write results
+  -p, --rkt-dir="": Directory with rkt binary
+  -s, --stage1-path="": Path to Stage1 image to use, default: coreos
   -d, --duration="10s": How long to run the ACI
   -h, --help[=false]: help for rkt-monitor
   -r, --repetitions=1: Numbers of benchmark repetitions
@@ -28,7 +31,7 @@ attempt to eat up resources in different ways.
 An example usage:
 
 ```
-derek@rokot ~/go/src/github.com/coreos/rkt> ./tests/rkt-monitor/build-stresser.sh log
+$ ./tests/rkt-monitor/build-stresser.sh log
 Building worker...
 Beginning build with an empty ACI
 Setting name of ACI to appc.io/rkt-log-stresser
@@ -36,7 +39,7 @@ Copying host:worker-binary to aci:/worker
 Setting exec command [/worker]
 Writing ACI to log-stresser.aci
 Ending the build
-derek@rokot ~/go/src/github.com/coreos/rkt> sudo ./build-rkt-1.8.0+git/bin/rkt-monitor log-stresser.aci 
+$ sudo ./build-rkt-1.10.0+git/target/bin/rkt-monitor log-stresser.aci 
 [sudo] password for derek: 
 rkt(13261): seconds alive: 10  avg CPU: 33.113897%  avg Mem: 4 kB  peak Mem: 4 kB
 systemd(13302): seconds alive: 9  avg CPU: 0.000000%  avg Mem: 4 mB  peak Mem: 4 mB

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -28,7 +28,7 @@ trap acbuildEnd EXIT
 
 acbuild --debug set-name appc.io/rkt-"${1}"-stresser
 
-acbuild --debug copy build-rkt-1.8.0+git/bin/"${1}"-stresser /worker
+acbuild --debug copy build-rkt-1.10.0+git/target/bin/"${1}"-stresser /worker
 
 acbuild --debug set-exec -- /worker
 

--- a/tests/rkt-monitor/main.go
+++ b/tests/rkt-monitor/main.go
@@ -19,10 +19,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -48,7 +48,10 @@ var (
 	flagDuration         string
 	flagShowOutput       bool
 	flagSaveToCsv        bool
+	flagCsvDir           string
 	flagRepetitionNumber int
+	flagRktDir           string
+	flagStage1Path       string
 
 	cmdRktMonitor = &cobra.Command{
 		Use:     "rkt-monitor IMAGE",
@@ -66,6 +69,9 @@ func init() {
 	cmdRktMonitor.Flags().StringVarP(&flagDuration, "duration", "d", "10s", "How long to run the ACI")
 	cmdRktMonitor.Flags().BoolVarP(&flagShowOutput, "show-output", "o", false, "Display rkt's stdout and stderr")
 	cmdRktMonitor.Flags().BoolVarP(&flagSaveToCsv, "to-file", "f", false, "Save benchmark results to files in a temp dir")
+	cmdRktMonitor.Flags().StringVarP(&flagCsvDir, "output-dir", "w", "/tmp", "Specify directory to write results")
+	cmdRktMonitor.Flags().StringVarP(&flagRktDir, "rkt-dir", "p", "", "Directory with rkt binary")
+	cmdRktMonitor.Flags().StringVarP(&flagStage1Path, "stage1-path", "s", "", "Path to Stage1 image to use")
 
 	flag.Parse()
 }
@@ -105,6 +111,13 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 		podManifest = true
 	}
 
+	var flavorType string
+	if flagStage1Path == "" {
+		flavorType = "stage1-coreos.aci"
+	} else {
+		_, flavorType = filepath.Split(flagStage1Path)
+	}
+
 	var execCmd *exec.Cmd
 	var loadAvg *load.AvgStat
 	var containerStarting, containerStarted, containerStopping, containerStopped time.Time
@@ -112,14 +125,31 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 	records := [][]string{{"Time", "PID name", "PID number", "RSS", "CPU"}}             // csv headers
 	summaryRecords := [][]string{{"Load1", "Load5", "Load15", "StartTime", "StopTime"}} // csv summary headers
 
+	var rktBinary string
+	if flagRktDir != "" {
+		rktBinary = flagRktDir + "/rkt"
+	} else {
+		rktBinary = "rkt"
+	}
+
 	for i := 0; i < flagRepetitionNumber; i++ {
 		containerStarting = time.Now()
 
-		if podManifest {
-			execCmd = exec.Command("rkt", "run", "--pod-manifest", args[0], "--net=default-restricted")
-		} else {
-			execCmd = exec.Command("rkt", "run", args[0], "--insecure-options=image", "--net=default-restricted")
+		// build argument list for execCmd
+		argv := []string{"run"}
+
+		if flagStage1Path != "" {
+			argv = append(argv, fmt.Sprintf("--stage1-path=%v", flagStage1Path))
 		}
+
+		if podManifest {
+			argv = append(argv, "--pod-manifest", args[0])
+		} else {
+			argv = append(argv, args[0], "--insecure-options=image")
+		}
+		argv = append(argv, "--net=default-restricted")
+
+		execCmd = exec.Command(rktBinary, argv...)
 
 		if flagShowOutput {
 			execCmd.Stdout = os.Stdout
@@ -216,19 +246,21 @@ func runRktMonitor(cmd *cobra.Command, args []string) {
 				strconv.FormatFloat(loadAvg.Load15, 'g', 3, 64),
 				strconv.FormatInt(containerStarted.Sub(containerStarting).Nanoseconds(), 10),
 				strconv.FormatInt(containerStopped.Sub(containerStopping).Nanoseconds(), 10)})
-		} else {
-			fmt.Printf("load average: Load1: %f Load5: %f Load15: %f\n", loadAvg.Load1, loadAvg.Load5, loadAvg.Load15)
-			fmt.Printf("container start time: %dns\n", containerStarted.Sub(containerStarting).Nanoseconds())
-			fmt.Printf("container stop time: %dns\n", containerStopped.Sub(containerStopping).Nanoseconds())
 		}
+
+		fmt.Printf("load average: Load1: %f Load5: %f Load15: %f\n", loadAvg.Load1, loadAvg.Load5, loadAvg.Load15)
+		fmt.Printf("container start time: %dns\n", containerStarted.Sub(containerStarting).Nanoseconds())
+		fmt.Printf("container stop time: %dns\n", containerStopped.Sub(containerStopping).Nanoseconds())
 	}
 
+	t := time.Now()
+	prefix := fmt.Sprintf("%d-%02d-%02d_%02d-%02d_%s_", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), flavorType)
 	if flagSaveToCsv {
-		err = saveRecords(records, "rkt_benchmark_interval_")
+		err = saveRecords(records, flagCsvDir, prefix+"rkt_benchmark_interval.csv")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't write to a file: %v\n", err)
 		}
-		err = saveRecords(summaryRecords, "rkt_benchmark_summary_")
+		err = saveRecords(summaryRecords, flagCsvDir, prefix+"rkt_benchmark_summary.csv")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Can't write to a summary file: %v\n", err)
 		}
@@ -352,8 +384,11 @@ func addRecords(statuses []*ProcessStatus, records [][]string) [][]string {
 	return records
 }
 
-func saveRecords(records [][]string, prefix string) error {
-	csvFile, err := ioutil.TempFile("", prefix)
+func saveRecords(records [][]string, dir, filename string) error {
+	if dir == "" {
+		dir = "/tmp"
+	}
+	csvFile, err := os.Create(filepath.Join(dir, filename))
 	defer csvFile.Close()
 	if err != nil {
 		return err

--- a/tools/cpu-stresser.mk
+++ b/tools/cpu-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,CPU_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-CPU_STRESSER := $(BINDIR)/cpu-stresser
+CPU_STRESSER := $(TARGET_BINDIR)/cpu-stresser
 BGB_STAMP := $(CPU_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/cpu-stresser
 BGB_BINARY := $(CPU_STRESSER)

--- a/tools/log-stresser.mk
+++ b/tools/log-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,LOG_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-LOG_STRESSER := $(BINDIR)/log-stresser
+LOG_STRESSER := $(TARGET_BINDIR)/log-stresser
 BGB_STAMP := $(LOG_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/log-stresser
 BGB_BINARY := $(LOG_STRESSER)

--- a/tools/mem-stresser.mk
+++ b/tools/mem-stresser.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,MEM_STRESSER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-MEM_STRESSER := $(BINDIR)/mem-stresser
+MEM_STRESSER := $(TARGET_BINDIR)/mem-stresser
 BGB_STAMP := $(MEM_STRESSER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/mem-stresser
 BGB_BINARY := $(MEM_STRESSER)

--- a/tools/rkt-monitor.mk
+++ b/tools/rkt-monitor.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,RKT_MONITOR_STAMP)
 
 # variables for makelib/build_go_bin.mk
-RKT_MONITOR := $(BINDIR)/rkt-monitor
+RKT_MONITOR := $(TARGET_BINDIR)/rkt-monitor
 BGB_STAMP := $(RKT_MONITOR_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor
 BGB_BINARY := $(RKT_MONITOR)

--- a/tools/sleeper.mk
+++ b/tools/sleeper.mk
@@ -1,7 +1,7 @@
 $(call setup-stamp-file,SLEEPER_STAMP)
 
 # variables for makelib/build_go_bin.mk
-SLEEPER := $(BINDIR)/sleeper
+SLEEPER := $(TARGET_BINDIR)/sleeper
 BGB_STAMP := $(SLEEPER_STAMP)
 BGB_PKG_IN_REPO := tests/rkt-monitor/sleeper
 BGB_BINARY := $(SLEEPER)


### PR DESCRIPTION
- Fix to build issue introduced with glide (BINDIR -> TARGET_BINDIR)
- Fix to build issue with rkt v1.10
- New flag: output-dir, CSV output files will be placed there
- New flag: rkt-dir: directory with rkt binary
- New flag: stage1-path: which flavor use in tests
- CSV output filename now contains date, time and flavor
- Output file flag don't prevents printing result summary to stdout
